### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/backend/canvas_app_explorer/lti1p3.py
+++ b/backend/canvas_app_explorer/lti1p3.py
@@ -66,7 +66,7 @@ def lti_error(error_message: Any) -> JsonResponse:
     :return: JsonResponse, with status 500
     """
     logger.error(f'LTI error: {error_message}')
-    return JsonResponse({'lti_error': f'{error_message}'}, status=500)
+    return JsonResponse({'lti_error': 'An internal error has occurred.'}, status=500)
 
 
 def generate_jwks() -> Dict[str, list]:


### PR DESCRIPTION
Fixes [https://github.com/tl-its-umich-edu/instructor-tools/security/code-scanning/1](https://github.com/tl-its-umich-edu/instructor-tools/security/code-scanning/1)

To fix the problem, we should modify the `lti_error` function to log the detailed error message on the server and return a generic error message to the end user. This approach ensures that sensitive information is not exposed while still allowing developers to access the detailed error logs for debugging purposes.

1. Modify the `lti_error` function to log the detailed error message.
2. Return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
